### PR TITLE
Fix double escaping of relay names

### DIFF
--- a/webinterface.cpp
+++ b/webinterface.cpp
@@ -251,7 +251,7 @@ void handleRelayData() {
   for (int i=0; i<NUM_RELAYS; i++) {
     if (i>0) js += ",";
     js += "{";
-    js += "\"name\":\"" + htmlEscape(relays[i].name) + "\",";
+    js += "\"name\":\"" + relays[i].name + "\",";
     js += "\"type\":\"" + relays[i].type + "\",";
     js += "\"state\":" + String(relayStates[i] ? "true":"false");
     js += "}";


### PR DESCRIPTION
## Summary
- stop HTML escaping relay names when generating JSON

## Testing
- `echo 'No tests'`

------
https://chatgpt.com/codex/tasks/task_e_687f919548688326bc68c24befe8f33a